### PR TITLE
Added question answers listing functionality

### DIFF
--- a/basecampy3/bc3_api.py
+++ b/basecampy3/bc3_api.py
@@ -12,6 +12,7 @@ import traceback
 from basecampy3.exc import *
 from .config import BasecampConfig
 from .token_requestor import TokenRequester
+from .endpoints import answers
 from .endpoints import campfires
 from .endpoints import campfire_lines
 from .endpoints import messages
@@ -108,6 +109,7 @@ class Basecamp3(object):
         self._session.headers['User-Agent'] = USER_AGENT
         self.account_id = None
         self._authorize()
+        self.answers = answers.Answers(self)
         self.campfires = campfires.Campfires(self)
         self.campfire_lines = campfire_lines.CampfireLines(self)
         self.messages = messages.Messages(self)

--- a/basecampy3/endpoints/answers.py
+++ b/basecampy3/endpoints/answers.py
@@ -1,0 +1,40 @@
+from . import _base
+import six
+
+
+@six.python_2_unicode_compatible
+class Answer(_base.BasecampObject):
+    """
+    A question answer on Basecamp 3
+    """
+
+    def __str__(self):
+        try:
+            return u"Answer {} - by {}".format(self.id, self.creator.get('name'))
+        except:
+            return super(Answer, self).__str__()
+
+
+class Answers(_base.BasecampEndpoint):
+    OBJECT_CLASS = Answer
+
+    LIST_ANSWERS_URL = "{base_url}/buckets/{project_id}/questions/{question_id}/answers.json"
+
+    def list(self, project, question):
+        """
+        Get a list of answers in question
+
+        :param project: a project containing question
+        :type project: basecampy3.endpoints.projects.Project|int
+        :param question: id of question to list answers from
+        :type question: int
+        :return: a list of Answer objects
+        :rtype: collections.Iterable[Answer]
+        """
+        assert project is not None
+        assert question is not None
+
+        project = int(project)
+        url = self.LIST_ANSWERS_URL.format(base_url=self.url, project_id=project, question_id=question)
+
+        return self._get_list(url)

--- a/basecampy3/endpoints/projects.py
+++ b/basecampy3/endpoints/projects.py
@@ -101,6 +101,17 @@ class Project(_base.BasecampObject):
         """
         return self._endpoint._api.people.list(project=self.id)
 
+    def list_answers_in_question(self, question):
+        """
+        A list of answers for question with id
+
+        :param question: the id of question to list answers from
+        :type name: int
+        :return: a list of Answer objects
+        :rtype: collections.Iterable[basecampy3.endpoints.answers.Answer]
+        """
+        return self._endpoint._api.answers.list(project=self.id, question=question)
+
     def _get_dock_section(self, name):
         for section in self.dock:
             if section['name'] == name:


### PR DESCRIPTION
This adds [Question answers](https://github.com/basecamp/bc3-api/blob/master/sections/question_answers.md#question-answers) API functionality. 

Better implementation would also include [Questions](https://github.com/basecamp/bc3-api/blob/master/sections/questions.md#questions), but in this PR I've only implemented bare minimum I personally need.